### PR TITLE
chore: esm and typescript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ typings/
 
 # dotenv environment variables file
 .env
-
+dist/*

--- a/fixup.js
+++ b/fixup.js
@@ -1,0 +1,10 @@
+/* eslint-disable strict */
+const fs = require('fs');
+
+fs.writeFileSync('dist/cjs/package.json', JSON.stringify({
+  type: 'commonjs',
+}, null, 2));
+
+fs.writeFileSync('dist/esm/package.json', JSON.stringify({
+  type: 'module',
+}, null, 2));

--- a/package.json
+++ b/package.json
@@ -2,10 +2,19 @@
   "name": "hash-equals",
   "version": "0.0.3",
   "description": "Timing attack safe string comparison",
-  "main": "index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.d.ts",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
+    }
+  },
   "scripts": {
+    "build": "NODE_ENV=production rollup -c && node fixup.js",
     "lint": "eslint test.js index.js --fix",
-    "test": "jest --forceExit",
+    "test": "jest --forceExit --detectOpenHandles",
     "test-cov": "npm run test -- --coverage"
   },
   "repository": {
@@ -23,13 +32,20 @@
   },
   "homepage": "https://github.com/killara/hash-equals#readme",
   "devDependencies": {
-    "eslint": "^8.0.0",
-    "eslint-config-egg": "^9.0.0",
-    "eslint-plugin-jest": "^25.0.1",
-    "jest": "^27.1.0"
+    "@rollup/plugin-typescript": "^8.3.1",
+    "@types/jest": "^27.4.1",
+    "eslint": "^8.11.0",
+    "eslint-config-egg": "^11.0.1",
+    "eslint-plugin-jest": "^26.1.1",
+    "jest": "^27.1.0",
+    "rollup": "^2.70.1",
+    "rollup-plugin-terser": "^7.0.2",
+    "ts-jest": "^27.1.3",
+    "tslib": "^2.3.1",
+    "typescript": "^4.6.2"
   },
   "files": [
-    "index.js"
+    "dist/*"
   ],
   "jest": {
     "coverageReporters": [
@@ -37,6 +53,7 @@
       "lcov"
     ],
     "bail": true,
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "preset": "ts-jest"
   }
 }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,0 +1,31 @@
+import { terser } from "rollup-plugin-terser";
+import ts from "@rollup/plugin-typescript";
+
+const production = process.env.NODE_ENV == "production";
+export default [
+  {
+    input: "src/index.ts",
+    output: {
+      dir: "dist/esm",
+      format: "esm",
+    },
+    plugins: [
+      ts({ declaration: true, outDir: "dist/esm"}),
+      production && terser(),
+    ],
+    external: ["assert", "crypto"],
+  },
+  {
+    input: "src/index.ts",
+    output: {
+      dir: "dist/cjs",
+      format: "cjs",
+      exports: "auto"
+    },
+    plugins: [
+      ts({ declaration: false, outDir: "dist/cjs"}),
+      production && terser(),
+    ],
+    external: ["assert", "crypto"],
+  }
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,10 @@
-'use strict';
-
 // Reimplement according to Brad Hill's Double HMAC pattern
 // https://www.nccgroup.trust/us/about-us/newsroom-and-events/blog/2011/february/double-hmac-verification/
 
-const assert = require('assert');
-const crypto = require('crypto');
+import assert from "assert"
+import crypto from "crypto"
 
-const hashEquals = (answer, guess) => {
+const hashEquals = (answer:string, guess:string) => {
 
   assert(typeof answer === 'string' && typeof guess === 'string', 'both arguments should be strings');
 
@@ -23,4 +21,4 @@ const hashEquals = (answer, guess) => {
   return result === 0;
 };
 
-module.exports = hashEquals;
+export default hashEquals

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,4 @@
-'use strict';
-
-const hashEquals = require('.');
+import hashEquals from "./src"
 
 describe('hash-equals', () => {
   test('has correct comparison', () => {
@@ -10,7 +8,7 @@ describe('hash-equals', () => {
   });
 
   test('shoud have both string arguments', () => {
-    expect(() => hashEquals(null, 'hash-equals')).toThrow(/both arguments should be strings/);
-    expect(() => hashEquals(null, undefined)).toThrow(/both arguments should be strings/);
+    expect(() => hashEquals(null as unknown as string, 'hash-equals')).toThrow(/both arguments should be strings/);
+    expect(() => hashEquals(null as unknown as string, undefined as unknown as string)).toThrow(/both arguments should be strings/);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,68 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "ESNext",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "ESNext",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "rootDir": "src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}


### PR DESCRIPTION
# ESM and Typescript support
Hi, this is great library. Currently this library only works on commonjs and will fail when imported to esm module.
```
const assert = require('assert');
               ^

ReferenceError: require is not defined in ES module scope, you can use import instead
```
This PR is to make this library support on esm, cjs and typescript.